### PR TITLE
Email driver should only send text email

### DIFF
--- a/src/SimpleSoftwareIO/SMS/Drivers/EmailSMS.php
+++ b/src/SimpleSoftwareIO/SMS/Drivers/EmailSMS.php
@@ -43,7 +43,7 @@ class EmailSMS implements DriverInterface
         $this->outgoingMessage = $message;
         $me = $this;
 
-        $this->mailer->send($this->outgoingMessage->getView(), $this->outgoingMessage->getData(), function ($email) use ($me) {
+        $this->mailer->send(['text' => $this->outgoingMessage->getView()], $this->outgoingMessage->getData(), function ($email) use ($me) {
             foreach ($me->outgoingMessage->getToWithCarriers() as $number) {
                 $email->to($me->buildEmail($number));
             }


### PR DESCRIPTION
The Laravel Mail driver sends HTML emails by default, and obviously text messages are not compatible with HTML. Mailtrap shows that without this modification, the message is treated as an HTML message, and thus it does not render the new lines. (`<br>` versus \n) Therefore, I suggest forcing the mail driver to only send text messages as text-based emails.
