### PR TITLE
Nexmo might reply with an error. We need to account for that.

### DIFF
--- a/src/SimpleSoftwareIO/SMS/Drivers/AbstractSMS.php
+++ b/src/SimpleSoftwareIO/SMS/Drivers/AbstractSMS.php
@@ -10,6 +10,7 @@
  */
 
 use SimpleSoftwareIO\SMS\IncomingMessage;
+use SimpleSoftwareIO\SMS\SMSNotSentException;
 
 abstract class AbstractSMS
 {
@@ -26,6 +27,18 @@ abstract class AbstractSMS
      * @var array
      */
     protected $auth = [];
+    
+    /**
+     * Throw a not sent exception
+     *
+     * @param $message
+     * @param $code = 0
+     * @throws SMSNotSentException
+     */
+    protected function throwNotSentException($message, $code = 0)
+    {
+    	throw new SMSNotSentException($message, $code);
+    }
 
     /**
      * Creates a new IncomingMessage instance.

--- a/src/SimpleSoftwareIO/SMS/Drivers/AbstractSMS.php
+++ b/src/SimpleSoftwareIO/SMS/Drivers/AbstractSMS.php
@@ -37,7 +37,7 @@ abstract class AbstractSMS
      */
     protected function throwNotSentException($message, $code = 0)
     {
-    	throw new SMSNotSentException($message, $code);
+        throw new SMSNotSentException($message, $code);
     }
 
     /**

--- a/src/SimpleSoftwareIO/SMS/Drivers/EmailSMS.php
+++ b/src/SimpleSoftwareIO/SMS/Drivers/EmailSMS.php
@@ -43,7 +43,7 @@ class EmailSMS implements DriverInterface
         $this->outgoingMessage = $message;
         $me = $this;
 
-        $this->mailer->send($this->outgoingMessage->getView(), $this->outgoingMessage->getData(), function ($email) use ($me) {
+        $this->mailer->send(['text' => $this->outgoingMessage->getView()], $this->outgoingMessage->getData(), function ($email) use ($me) {
             foreach ($me->outgoingMessage->getToWithCarriers() as $number) {
                 $email->to($me->buildEmail($number));
             }

--- a/src/SimpleSoftwareIO/SMS/Drivers/NexmoSMS.php
+++ b/src/SimpleSoftwareIO/SMS/Drivers/NexmoSMS.php
@@ -105,7 +105,6 @@ class NexmoSMS extends AbstractSMS implements DriverInterface
             $error = $firstMessage['error-text'];
         }
         
-        \Log::error($error);
         $this->throwNotSentException($error, $firstMessage['status']);
     }
     

--- a/src/SimpleSoftwareIO/SMS/SMS.php
+++ b/src/SimpleSoftwareIO/SMS/SMS.php
@@ -20,6 +20,8 @@ use Illuminate\Queue\QueueManager;
 use Illuminate\Container\Container;
 use SimpleSoftwareIO\SMS\Drivers\DriverInterface;
 
+class SMSNotSentException extends \Exception{}
+
 class SMS
 {
     /**


### PR DESCRIPTION
When Nexmo receives a request to send a message, it might reply with an error message. I've added in the functionality to check for errors in the response. I've also added in a new exception which is thrown from the abstract driver in case you'd like to handle errors in other drivers.
