### PR TITLE
Easy way to add a new driver, without modification of DriverManager

### DIFF
--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -4,6 +4,7 @@ namespace SimpleSoftwareIO\SMS;
 
 use GuzzleHttp\Client;
 use Illuminate\Support\Manager;
+use InvalidArgumentException;
 use SimpleSoftwareIO\SMS\Drivers\CallFireSMS;
 use SimpleSoftwareIO\SMS\Drivers\EmailSMS;
 use SimpleSoftwareIO\SMS\Drivers\EZTextingSMS;
@@ -38,6 +39,27 @@ class DriverManager extends Manager
     public function setDefaultDriver($name)
     {
         $this->app['config']['sms.driver'] = $name;
+    }
+
+    /**
+     * Create a new driver instance.
+     *
+     * @param  string  $driver
+     * @return mixed
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function createDriver($driver)
+    {
+        try {
+            return parent::createDriver($driver);
+        } catch (InvalidArgumentException $e) {
+            if (class_exists($driver)) {
+                return $this->app->make($driver);
+            }
+
+            throw $e;
+        }
     }
 
     /**

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -44,10 +44,11 @@ class DriverManager extends Manager
     /**
      * Create a new driver instance.
      *
-     * @param  string  $driver
-     * @return mixed
+     * @param string $driver
      *
      * @throws \InvalidArgumentException
+     *
+     * @return mixed
      */
     protected function createDriver($driver)
     {


### PR DESCRIPTION
As a description, I will cite the [docs](https://github.com/SimpleSoftwareIO/simple-sms/pull/69/files#diff-92e1b6f62f68764bcff08dd8e34b1dd0R528):

> ## Creating Custom Driver
> 
> Create your custom driver class in place, where Composer can autoload it. You can use following template to start with:
>
> ```php
> 	namespace App\SMS\Drivers;
> 	
> 	use SimpleSoftwareIO\SMS\DoesNotReceive;
> 	use SimpleSoftwareIO\SMS\Drivers\DriverInterface;
> 	use SimpleSoftwareIO\SMS\OutgoingMessage;
> 	
> 	class DemoDriver implements DriverInterface
> 	{
> 	    use DoesNotReceive;
> 	
> 	    private $api_key;
> 	
> 	    function __construct($api_key)
> 	    {
> 	        $this->api_key = $api_key;
> 	    }
> 	
> 	    public function send(OutgoingMessage $message)
> 	    {
> 	        dd(
> 	        	$this->api_key,
> 	        	$message->getFrom(),
> 	        	$message->getTo(),
> 	        	$message->composeMessage()
> 	       	);
> 	    }
> 	}
>``` 	
>
> To use this custom driver set `SMS_DRIVER` enviroment varible (.env) to fully qualified class name, for example:
>
> ```
> 	SMS_DRIVER=App\SMS\Drivers\DemoDriver
> ```
>
> Alternatively you can change `driver` key in your `sms.php` config file, for example:
>
> ```
> 	    'driver' => App\SMS\Drivers\DemoDriver::class,
>```    
>
> ## Injecting custom attributes to driver
> 
> If you need to pass custom attributes to your driver like api key or HTTP client, you can use Laravel Dependency Injection. For example, in `register` method of your service provider, you can bind your custom parameters:
> 
>```php
> 	    public function register()
> 	    {
> 	        $this->app->bind(\App\SMS\Drivers\DemoDriver::class, function ($app) {
> 	            return new \App\SMS\Drivers\DemoDriver(
> 	                $app['config']->get('sms.demodriver.api_key', null)
> 	            );
> 	        });
> 	    }
>```